### PR TITLE
PR from feature/output-testcase to main

### DIFF
--- a/backend/output/serializers.py
+++ b/backend/output/serializers.py
@@ -3,6 +3,7 @@ from output.models import Result, FunctionalityResult, EfficiencyResult, Plagiar
 
 
 class TestcaseResultSerializer(serializers.Serializer):
+    id = serializers.IntegerField()
     is_hidden = serializers.BooleanField()
     input = serializers.CharField(allow_null=True)
     is_error = serializers.BooleanField()
@@ -15,6 +16,18 @@ class TestcaseResultSerializer(serializers.Serializer):
 
     def to_representation(self, instance):
         return super().to_representation(instance=instance)
+
+
+class TestcaseBlindResultSerializer(TestcaseResultSerializer):
+    blind_fields = ['input', 'expected_output', 'actual_output']
+
+    def to_representation(self, instance):
+        ret = super().to_representation(instance)
+        if instance.get('is_hidden'):
+            ret.update(
+                (key, None) for key in ret.keys() if key in self.blind_fields
+            )
+        return ret
 
 
 class FunctionalityResultSerializer(serializers.ModelSerializer):

--- a/backend/output/urls.py
+++ b/backend/output/urls.py
@@ -1,13 +1,14 @@
 from django.urls import path
-from output.views import retrieve_exercise_output, retrieve_testcase_output, ResultListOrCreate, ResultRetrieve
+from output.views import execute_exercise_output, execute_testcase_output, execute_testcases_output, ResultListOrCreate, ResultRetrieve
 
 
 urlpatterns = [
-    path('exercises/', retrieve_exercise_output, name='retrieve_exercise'),
+    path('exercises/', execute_exercise_output, name='execute_exercise'),
 ]
 
 urlpatterns += [
-    path('testcases/<int:testcase_id>/', retrieve_testcase_output, name='retrieve_testcase'),
+    path('testcases/<int:testcase_id>/', execute_testcase_output, name='execute_testcase'),
+    path('testcases/', execute_testcases_output, name='execute_testcases')
 ]
 
 urlpatterns += [

--- a/backend/output/utils_functionality.py
+++ b/backend/output/utils_functionality.py
@@ -1,6 +1,6 @@
 from output import utils_execution
 from testcase.models import Testcase
-from output.serializers import TestcaseResultSerializer, FunctionalityResultSerializer
+from output.serializers import TestcaseResultSerializer, TestcaseBlindResultSerializer, FunctionalityResultSerializer
 from output.utils import string_compare_considered_type
 
 
@@ -22,7 +22,7 @@ def run(result_id: int, testcases: [Testcase], base_dir: str, language: str, raw
     return serializer.data
 
 
-def generate_testcase_results(base_dir: str, language: str, raw_code: str, testcases: [Testcase]):
+def generate_testcase_results(base_dir: str, language: str, raw_code: str, testcases: [Testcase], blind: bool = False):
     ret = list()
     for idx, testcase in enumerate(testcases):
         execution_output = utils_execution.run(
@@ -50,14 +50,20 @@ def generate_testcase_results(base_dir: str, language: str, raw_code: str, testc
             expected_output = None
             actual_output = None
 
-        serializer = TestcaseResultSerializer(instance={
+        instance = {
+            'id': testcase.id,
             'is_hidden': testcase.is_hidden,
             'input': testcase_input,
             'expected_output': expected_output,
             'actual_output': actual_output,
             'is_error': is_error,
             'is_pass': is_pass,
-        })
+        }
+
+        if blind:
+            serializer = TestcaseBlindResultSerializer(instance=instance)
+        else:
+            serializer = TestcaseResultSerializer(instance=instance)
         ret.append(serializer.data)
 
     return ret

--- a/docs/api-schema.md
+++ b/docs/api-schema.md
@@ -29,7 +29,8 @@
 |            | PUT       | /repos/{repo_id}/                 | 풀이 코드 저장                |
 |            | DELETE    | /repos/{repo_id}/                 | 풀이 코드 제거                |
 | Output     | POST      | /outputs/exercises/               | 풀이 코드 실행 및 결과 전달        |
-|            | POST      | /outputs/testcases/{testcase_id}/ | 테스트 케이스 결과 전달           |
+|            | POST      | /outputs/testcases/               | 모든 테스트 케이스 결과 전달        |
+|            | POST      | /outputs/testcases/{testcase_id}/ | 특정 테스트 케이스 결과 전달        |
 |            | GET       | /outputs/results/                 | 모든 과제 제출 결과 조희          |
 |            | POST      | /outputs/results/                 | 과제 제출                   |
 |            | GET       | /outputs/results/{result_id}/     | 특정 과제 제출 결과 조회          |
@@ -280,15 +281,25 @@ Acesss Token 재발급
 
 - Response: `eixt_status`, `output`
 
+### POST /outputs/testcases/
+
+모든 테스트 케이스 결과 전달
+
+공개 테스트인 경우 실행 결과를 노출, 비공개인 경우 세부 정보가 노출되지 않음
+
+- Request: `auth (required)`, `language`, `code`, `assignment_id`
+
+- Response: `id`, `is_hidden`, `input`, `is_error`, `expected_output`, `actual_output`, `is_pass`
+
 ### POST /outputs/testcases/{testcase_id}/
 
-테스트 케이스 결과 전달
+특정 테스트 케이스 결과 전달
 
-공개 테스트 케이스인 경우 실행 결과를 노출, 비공개인 경우 노출하지 않음
+공개 테스트 케이스인 경우 실행 결과를 노출, 비공개인 경우 요청 거부됨
 
 - Request: `auth (required)`, `language`, `code`
 
-- Response: `input`, `is_error`, `expected_output`, `actual_output`, `is_pass`
+- Response: `id`, `is_hidden`, `input`, `is_error`, `expected_output`, `actual_output`, `is_pass`
 
 ### GET /outputs/results/
 


### PR DESCRIPTION
지난 회의 때 논의된 `Testcase` 실행 관련 API 수정 및 추가했습니다.

| Component  | Method    | API                               | Function                |
| ---------- | --------- |-----------------------------------|-------------------------|
| Output           | POST      | /outputs/testcases/               | 모든 테스트 케이스 결과 전달        |
|            | POST      | /outputs/testcases/{testcase_id}/ | 특정 테스트 케이스 결과 전달        |

### POST /outputs/testcases/

모든 테스트 케이스 결과 전달

공개 테스트인 경우 실행 결과를 노출, 비공개인 경우 세부 정보가 노출되지 않음

- Request: `auth (required)`, `language`, `code`, `assignment_id`

- Response: `id`, `is_hidden`, `input`, `is_error`, `expected_output`, `actual_output`, `is_pass`

### POST /outputs/testcases/{testcase_id}/

특정 테스트 케이스 결과 전달

공개 테스트 케이스인 경우 실행 결과를 노출, 비공개인 경우 요청 거부됨

- Request: `auth (required)`, `language`, `code`

- Response: `id`, `is_hidden`, `input`, `is_error`, `expected_output`, `actual_output`, `is_pass`