### PR TITLE
과제 제출 후 히든 테스트케이스 상세 정보 제공

### DIFF
--- a/backend/output/test_utils_functionality.py
+++ b/backend/output/test_utils_functionality.py
@@ -72,15 +72,16 @@ def solution():
     def test_generate_functionality_result(self):
         result = Result.objects.first()
         testcases = Testcase.objects.all()
-        testcase = Testcase.objects.first()
+        public_testcase = Testcase.objects.first()
+        private_testcase = Testcase.objects.last()
 
         ret = run(result.id, testcases, SERVER_CODE_DIR, self.language, self.code)
 
         self.assertIsNotNone(ret.get('id'))
         self.assertEqual(len(ret.get('testcase_results')), 2)
-        self.assertEqual(ret.get('testcase_results')[0].get('input'), testcase.input)
-        self.assertEqual(ret.get('testcase_results')[0].get('expected_output'), testcase.output)
+        self.assertEqual(ret.get('testcase_results')[0].get('input'), public_testcase.input)
+        self.assertEqual(ret.get('testcase_results')[0].get('expected_output'), public_testcase.output)
         self.assertIsNotNone(ret.get('testcase_results')[0].get('actual_output'))
-        self.assertIsNone(ret.get('testcase_results')[1].get('input'))
-        self.assertIsNone(ret.get('testcase_results')[1].get('expected_output'))
-        self.assertIsNone(ret.get('testcase_results')[1].get('actual_output'))
+        self.assertEqual(ret.get('testcase_results')[1].get('input'), private_testcase.input)
+        self.assertEqual(ret.get('testcase_results')[1].get('expected_output'), private_testcase.output)
+        self.assertIsNotNone(ret.get('testcase_results')[1].get('actual_output'))

--- a/backend/output/test_views.py
+++ b/backend/output/test_views.py
@@ -298,13 +298,13 @@ class TestResultListOrCreate(TestCase):
             assignment=assignment,
             is_hidden=False,
             input='3\n1 2 3\n',
-            output='6.0\n'
+            output='6.0'
         )
         testcase_2 = Testcase.objects.create(
             assignment=assignment,
             is_hidden=True,
             input='3\n1.1 2.2 3.3',
-            output='6.6\n',
+            output='6.6',
         )
         repo_1 = Repo.objects.create(
             assignment=assignment,

--- a/backend/output/utils_functionality.py
+++ b/backend/output/utils_functionality.py
@@ -45,11 +45,6 @@ def generate_testcase_results(base_dir: str, language: str, raw_code: str, testc
             actual_output = execution_output.get('output')
             is_pass = string_compare_considered_type(actual_output, expected_output)
 
-        if testcase.is_hidden:
-            testcase_input = None
-            expected_output = None
-            actual_output = None
-
         instance = {
             'id': testcase.id,
             'is_hidden': testcase.is_hidden,


### PR DESCRIPTION
#55 

현재 API는 과제 제출 후에도 히든 테스트케이스 상세 정보를 제공하지 않고 있습니다
이를 수정했습니다.